### PR TITLE
Use relative paths in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "slang"]
 	path = slang
-	url = git@github.com:GREEN-ITMO-YADRO/slang.git
+	url = ../slang.git
+
 [submodule "circt"]
 	path = circt
-	url = git@github.com:GREEN-ITMO-YADRO/circt.git
+	url = ../circt.git
+
 [submodule "risc-v"]
 	path = risc-v
-	url = git@github.com:GREEN-ITMO-YADRO/risc-v.git
+	url = ../risc-v.git

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# Risc-V Circt Flow
-
-This repository contains the main flow 
+# RISC-V Circt Flow
+This repository contains the main flow.
 
 ## Setting this up
 1. **Install git submodules**
+
 ```
 $ git clone git@github.com:GREEN-ITMO-YADRO/flow.git
 $ cd flow
-$ git submodule init
-$ git submodule update
+$ git submodule update --init --recursive --progress
 ```


### PR DESCRIPTION
Так как все репозитории в одном и том же месте расположены, имеет смысл использовать относительные пути. Тем более, что скоро абсолютные пути поменяются из-за переименований. Кроме того, это позволяет пользователям инициализировать подмодули без необходимости настраивать SSH-ключи для доступа.

Работу проверил: зависимости собираются. Дописал в `README.md` флаг `--recursive`, так как он такой и нужен.