### PR TITLE
Support running testbenches

### DIFF
--- a/scripts/remove-outer-module.awk
+++ b/scripts/remove-outer-module.awk
@@ -1,0 +1,11 @@
+{
+  if (!inside && $0 ~ /^module/) {
+    inside = 1
+  } else if (inside && $0 ~ /^}/) {
+    inside = 0
+  } else {
+    # strip the leading indent.
+    sub(/^  /, "")
+    print
+  }
+}


### PR DESCRIPTION
Тестбенчи определяются в директории `testbenches` репозитория menace как файлы в формате MLIR с аннотациями FileCheck. Один пример такого тестбенча уже закинул.

Зависимости тестбенча указываются в мейкфайле под "testbench dependencies".

Запуск тестбенча производится командой `make test`. Для запуска конкретного тестбенча из нескольких можно указать их имена в `TESTBENCHES`, например `make test TESTBENCHES=alu` (запустит `testbenches/alu.mlir`).

См. #27.